### PR TITLE
Fixed a race condition for LogGroup

### DIFF
--- a/badges.template
+++ b/badges.template
@@ -203,6 +203,7 @@ Resources:
         - Arn
 
   Badges:
+    DependsOn: LambdaLogGroup
     Type: Custom::Badges
     Properties:
       ServiceToken: !GetAtt Lambda.Arn


### PR DESCRIPTION
CloudFormation cannot create a LogGroup resource for the existing
LogGroup. So, there was a race when Lambda got a chance to execute
before the corresponding LogGroup was created.  This commit
addresses the issue by introducing a dependency between the trigger
of the Lambda execution and the LogGroup creation.