### PR TITLE
Update the documentation on the nested stack usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,51 +62,28 @@ $ aws cloudformation deploy --template-file badges.template \
 ```
 
 
-Part of another template (nested stack) using JSON notation:
-```json
-…
-"Resources": {
-…
-        "Badges": {
-                "Type": "AWS::CloudFormation::Stack",
-                "Properties": {
-                        "TemplateURL": { "Fn::Sub": "https://${BucketWithTemplate}.s3-${AWS::Region}.amazonaws.com/badges.template" },
-                        "Parameters": {
-                                "CodeBuildProjects": [
-                                        { "Ref": "Project1" },
-                                        { "Ref": "Project2" },
-                                        { "Ref": "Project3" }
-                                ],
-                                "CodePipelines": [
-                                        { "Ref": "Pipeline1" },
-                                        { "Ref": "Pipeline2" }
-                                ]
-                        },
-                        "TimeoutInMinutes": "15"
-                }
-        },
-…
-}
-```
-
-Part of another template (a nested stack) using YAML notation:
+As a part of another template (a nested stack) using YAML notation:
 ```yaml
 …
 Resources:
 …
-    Badges:
-        Type: AWS::CloudFormation::Stack
-        Properties:
-            TemplateURL: !Sub 'https://${BucketWithTemplate}.s3-${AWS::Region}.amazonaws.com/badges.template'
-            Parameters:
-                CodeBuildProjects:
-                    - Project1
-                    - Project2
-                    - Project3
-                CodePipelines:
-                    - Pipeline1
-                    - Pipeline2
-            TimeoutInMinutes: 15
+  Badges:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'https://${BucketWithTemplate}.s3-${AWS::Region}.amazonaws.com/badges.template'
+      Parameters:
+        CodeBuildProjects: !Join
+          - ','
+          -
+            - Project1
+            - Project2
+            - Project3
+        CodePipelines: !Join
+          - ','
+          -
+            - Pipeline1
+            - Pipeline2
+      TimeoutInMinutes: 15
 …
 ```
 


### PR DESCRIPTION
AWS CloudFormation expect all parameters for the nested stacks to
be simple strings even when the nested template expects a list.
So, we need to flatten the list into a comma delimited string
before we pass it on to the nested steck.

Fixes #3.